### PR TITLE
Use absolute paths to load libraries

### DIFF
--- a/java-package/openbci_gui_helpers/src/main/java/openbci_gui_helpers/GUIHelper.java
+++ b/java-package/openbci_gui_helpers/src/main/java/openbci_gui_helpers/GUIHelper.java
@@ -47,8 +47,8 @@ public class GUIHelper
         unpack_from_jar (lib_name);
         unpack_from_jar (lib_native_name);
 
-        instance = (DllInterface) Native.loadLibrary (lib_name, DllInterface.class);
-        instance_native = (DllNativeInterface) Native.loadLibrary (lib_native_name, DllNativeInterface.class);
+        instance = (DllInterface) Native.load (new File (lib_name).getAbsolutePath (), DllInterface.class);
+        instance_native = (DllNativeInterface) Native.load (new File (lib_native_name).getAbsolutePath (), DllNativeInterface.class);
     }
 
     private static void unpack_from_jar (String lib_name)

--- a/java-package/openbci_gui_helpers/src/main/java/openbci_gui_helpers/GUIHelper.java
+++ b/java-package/openbci_gui_helpers/src/main/java/openbci_gui_helpers/GUIHelper.java
@@ -44,14 +44,14 @@ public class GUIHelper
         }
 
         // need to extract libraries from jar
-        unpack_from_jar (lib_name);
-        unpack_from_jar (lib_native_name);
+        String lib_path = unpack_from_jar (lib_name);
+        String lib_native_path = unpack_from_jar (lib_native_name);
 
-        instance = (DllInterface) Native.load (new File (lib_name).getAbsolutePath (), DllInterface.class);
-        instance_native = (DllNativeInterface) Native.load (new File (lib_native_name).getAbsolutePath (), DllNativeInterface.class);
+        instance = (DllInterface) Native.load (lib_path, DllInterface.class);
+        instance_native = (DllNativeInterface) Native.load (lib_native_path, DllNativeInterface.class);
     }
 
-    private static void unpack_from_jar (String lib_name)
+    private static String unpack_from_jar (String lib_name)
     {
         try
         {
@@ -60,9 +60,11 @@ public class GUIHelper
                 file.delete ();
             InputStream link = (GUIHelper.class.getResourceAsStream (lib_name));
             Files.copy (link, file.getAbsoluteFile ().toPath ());
+            return file.getAbsolutePath();
         } catch (Exception io)
         {
             System.err.println ("native library: " + lib_name + " is not found in jar file");
+            return "";
         }
     }
 


### PR DESCRIPTION
In order to add [entitlements](https://developer.apple.com/documentation/bundleresources/entitlements) to MacOS applications and get it notarized by Apple, the program has to meet [hardened runtime](https://developer.apple.com/documentation/security/hardened_runtime) requirements. Using entitlements is required to allow embedded plugins to access different permissions on MacOS. The hardened runtime requirements disallow using relative paths for dynamic libraries to prevent [dynamic library hijacking](https://attack.mitre.org/techniques/T1574/006/). This PR updates the library loading implementation to use absolute paths.